### PR TITLE
OMA-76 Update educandu to v0.43.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,6 +33,7 @@ const omaEnv = {
   OMA_SESSION_COOKIE_DOMAIN: 'localhost',
   OMA_SESSION_COOKIE_NAME: 'SESSION_ID_OMA_LOCAL',
   OMA_CONSENT_COOKIE_NAME_PREFIX: 'CONSENT_OMA_LOCAL',
+  OMA_UPLOAD_LIABILITY_COOKIE_NAME: 'UPLOAD_LIABILITY_OMA_LOCAL',
   OMA_EMAIL_SENDER_ADDRESS: 'educandu-test-app@test.com',
   OMA_SMTP_OPTIONS: 'smtp://127.0.0.1:8025/?ignoreTLS=true',
   OMA_INITIAL_USER: JSON.stringify({ username: 'test', password: 'test', email: 'test@test.com' }),

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "private": true,
   "dependencies": {
-    "@educandu/educandu": "0.42.0",
+    "@educandu/educandu": "0.43.0",
     "@educandu/node-jsx-loader": "~2.2.0",
     "parseboolean": "~1.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ const config = {
   sessionCookieDomain: processEnv.OMA_SESSION_COOKIE_DOMAIN,
   sessionCookieName: processEnv.OMA_SESSION_COOKIE_NAME,
   consentCookieNamePrefix: processEnv.OMA_CONSENT_COOKIE_NAME_PREFIX,
+  uploadLiabilityCookieName: processEnv.OMA_UPLOAD_LIABILITY_COOKIE_NAME,
   emailSenderAddress: processEnv.OMA_EMAIL_SENDER_ADDRESS,
   smtpOptions: processEnv.OMA_SMTP_OPTIONS,
   initialUser: processEnv.OMA_INITIAL_USER ? JSON.parse(processEnv.OMA_INITIAL_USER) : null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,10 +378,10 @@
     yaml "^1.10.2"
     yargs "^17.3.1"
 
-"@educandu/educandu@0.42.0":
-  version "0.42.0"
-  resolved "https://registry.yarnpkg.com/@educandu/educandu/-/educandu-0.42.0.tgz#2d483f6018344e5e60212b26a3965718a9e0c9a8"
-  integrity sha512-oCEqAAyiosRa6OrZOcog18p4T/vicmKLPEdgyOzUO/PhjvnhQthYvp0sm/EYhhMMTCquYJYHs4dZWhbBfdm0Hw==
+"@educandu/educandu@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@educandu/educandu/-/educandu-0.43.0.tgz#1815953b0392eeaa746d7daf5bd8ffa453fd3d55"
+  integrity sha512-RqLL+eSYjg9Ov0S1H7q49T/E9vw8maJjVZ6jz5ixjKFlKhnnKeI0UyLFOLCXxz23aQdRxWzOBGu9x52GwX1D/g==
   dependencies:
     "@ant-design/icons" "^4.7.0"
     "@educandu/node-jsx-loader" "^2.2.0"


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/OMA-76

Octopus setup:

<img width="1685" alt="Screen Shot 2022-05-24 at 09 05 30" src="https://user-images.githubusercontent.com/8189923/169969692-ac1b2e39-2850-4b36-bfbf-aee4ebe0dc7b.png">
